### PR TITLE
Fix transparent screenshots by ensuring framebuffer is created with alpha channel

### DIFF
--- a/src/context_gl.h
+++ b/src/context_gl.h
@@ -23,8 +23,8 @@ public:
 			PFD_DRAW_TO_WINDOW | PFD_SUPPORT_OPENGL | PFD_DOUBLEBUFFER,    // Flags
 			PFD_TYPE_RGBA,        // The kind of framebuffer. RGBA or palette.
 			32,                   // Colordepth of the framebuffer.
-			0, 0, 0, 0, 0, 0,
-			0,
+			8, 0, 8, 0, 8, 0,
+			8,
 			0,
 			0,
 			0, 0, 0, 0,

--- a/src/main_frame.cpp
+++ b/src/main_frame.cpp
@@ -6,6 +6,7 @@
 
 #include <fstream>
 #include <filesystem>
+#include <sstream>
 
 #include <imgui.h>
 #include <imgui_internal.h>


### PR DESCRIPTION
The 'P' key creates screenshots which are intended to have transparent backgrounds but were bugged to be on all-black instead. This is because the framebuffer was created with no alpha channel, which meant glReadPixels inserted the default alpha of 255 when reading from it. 

This commit fixes that and allows creating transparent-background screenshots